### PR TITLE
feat: add Hungarian translation

### DIFF
--- a/MMM-WeeklySchedule.js
+++ b/MMM-WeeklySchedule.js
@@ -160,6 +160,7 @@ Module.register("MMM-WeeklySchedule", {
 				nb: "translations/nb.json",
 				nn: "translations/nn.json",
 				he: "translations/he.json",
+				hu: "translations/hu.json",
 				da: "translations/da.json",
 				pl: "translations/pl.json"
 		}

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -1,0 +1,4 @@
+{
+    "ON_DAY": "",
+    "NO_LESSONS": "Nincs tanítás."
+}


### PR DESCRIPTION
This PR adds Hungarian support to the module. In Hungarian we don't use prefixes for weekday names, but instead we use conjugation. So "Thursday" is "csütörtök", but "on Thursday" is "csütörtökön", which would need a mapping for all 7 days, so instead I decided to leave that resource key empty.

Thanks for creating and sharing this module!