### PR TITLE
Allow per-day timeslots

### DIFF
--- a/MMM-WeeklySchedule.js
+++ b/MMM-WeeklySchedule.js
@@ -65,6 +65,10 @@ Module.register("MMM-WeeklySchedule", {
 
 		// get timeslots
 		var timeslots = this.config.schedule.timeslots;
+		if ("timeslots" in lessons) {
+			timeslots = lessons.timeslots;
+			lessons = lessons.lessons;
+		}
 
 		// build table with timeslot definitions and lessons
 		wrapper = document.createElement("table");


### PR DESCRIPTION
Our local schools let out an hour early on Wednesdays, and so I added the ability for a `lessons` entry to be a map containing `timeslots` and `lessons` keys that will apply for that day only.

An example using this feature:

```js
config: {
  schedule: {
    timeslots: ["8:00", "9:00"],
    lessons: {
      mon: ["First lesson", "Second Lesson"],
      wed: {
        timeslots: ["8:00", "8:30"],
        lessons: ["Short lesson", "Short lesson 2"]
      }
    }
  }
}
```