### PR TITLE
Allow referencing another day by name to use its lessons

### DIFF
--- a/MMM-WeeklySchedule.js
+++ b/MMM-WeeklySchedule.js
@@ -62,6 +62,9 @@ Module.register("MMM-WeeklySchedule", {
 				this.translate("NO_LESSONS")
 			);
 		}
+		else if (typeof lessons === "string" || lessons instanceof String) {
+			lessons = this.config.schedule.lessons[lessons];
+		}
 
 		// get timeslots
 		var timeslots = this.config.schedule.timeslots;


### PR DESCRIPTION
When having multiple days with the same lessons, instead of retying the array, allow the user to reference another day by name:

```js
config: {
  schedule: {
    timeslots: ["8:00", "9:00"],
    lessons: {
      mon: ["First lesson", "Second Lesson"],
      wed: "mon"
    }
  }
}
```